### PR TITLE
Considered cable.yml to rename channel prefix

### DIFF
--- a/lib/generators/rename/shared/common_methods.rb
+++ b/lib/generators/rename/shared/common_methods.rb
@@ -57,6 +57,8 @@ module CommonMethods
       replace_into_file('config/initializers/session_store.rb', /(('|")_.*_session('|"))/i, "'_#{@new_key}_session'")
       #Rename database
       replace_into_file('config/database.yml', /#{@old_module_name.underscore}/i, @new_name.underscore)
+      #Rename cable
+      replace_into_file('config/cable.yml', /(#{@old_module_name}|#{@old_module_name.underscore})/i, @new_name)
     end
   end
 


### PR DESCRIPTION
@morshedalam

Hi. I included `cable.yml` which is required for action cable to replacement target file.
Test results are as follows.

|  old app name  |  new app name  | prefix channel name before renaming | prefix channel name after renaming |
| ---- | ---- |  ---- |  ---- |
|  OldApp  |  NewApp  | OldApp_production | NewApp_production |
|  old_app  |  new_app  | old_app_production | new_app_production |

I also tested that even if action cable is not configured, no error occurs.
