### PR TITLE
Remove deprecated File.exists?

### DIFF
--- a/lib/generators/rename/shared/common_methods.rb
+++ b/lib/generators/rename/shared/common_methods.rb
@@ -45,7 +45,7 @@ module CommonMethods
       raise Thor::Error, '[Error] Please give a name which does not match any of the reserved Rails keywords.'
     elsif Object.const_defined?(@new_module_name)
       raise Thor::Error, "[Error] Constant #{@new_module_name} is already in use, please choose another name."
-    elsif File.exists?(@new_path)
+    elsif File.exist?(@new_path)
       raise Thor::Error, '[Error] Already in use, please choose another name.'
     end
   end
@@ -124,7 +124,7 @@ module CommonMethods
   end
 
   def replace_into_file(file, search_exp, replace)
-    return if File.directory?(file) || !File.exists?(file)
+    return if File.directory?(file) || !File.exist?(file)
 
     begin
       gsub_file file, search_exp, replace


### PR DESCRIPTION
This PR updates the usage of `File.exists?` to `File.exist?` since the method has been removed on recent Ruby updates.


Reference: https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2