### PR TITLE
Add Rails 8 compatibility and fix underscore handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This gem allows you to rename your Rails application by using a single command.
 
-Tested up to Ruby 3.2.2 and Rails 7.0.8
+Tested up to Ruby 3.4.5 and Rails 8.0.2
 
 ## Installation
 
@@ -41,18 +41,24 @@ Search and replace exact module name to...
   config/initializers/permissions_policy.rb
   config/puma.rb
   config/routes.rb
+  config/deploy.yml (Rails 8)
   app/views/layouts/application.html.erb
   app/views/layouts/application.html.haml
   app/views/layouts/application.html.slim
+  app/views/pwa/manifest.json.erb (Rails 8)
   README.md
   README.markdown
   README.mdown
   README.mkdn
+  Dockerfile (if present)
 Search and replace underscore seperated module name to...
-  config/initializers/session_store.rb
+  config/initializers/session_store.rb (if present)
   config/database.yml
+  config/database.yml (Rails 8 multi-db: cache, queue, cable)
+  config/database.yml (environment variables)
   config/cable.yml
   config/environments/production.rb
+  config/deploy.yml (Rails 8 Kamal service names)
   package.json
 Removing references...
   .idea

--- a/lib/generators/rename/shared/common_methods.rb
+++ b/lib/generators/rename/shared/common_methods.rb
@@ -47,7 +47,7 @@ module CommonMethods
       raise Thor::Error, '[Error] Please give a name which does not match any of the reserved Rails keywords.'
     elsif Object.const_defined?(@new_module_name)
       raise Thor::Error, "[Error] Constant '#{@new_module_name}' is already in use, please choose another name."
-    elsif file_exist?(@new_path)
+    elsif file_exist?(@new_path) && @new_path != Rails.root.to_s
       raise Thor::Error, "[Error] Folder '#{@new_dir}' already in use, please choose another name."
     end
   end

--- a/tests/hyphen_handling_test.rb
+++ b/tests/hyphen_handling_test.rb
@@ -1,0 +1,126 @@
+require 'test_helper'
+require 'fileutils'
+require 'tmpdir'
+
+class HyphenHandlingTest < ActiveSupport::TestCase
+  def setup
+    @temp_dir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@temp_dir)
+  end
+
+  test "handles app names with hyphens correctly" do
+    # Create a mock Rails app structure with hyphenated name
+    app_dir = File.join(@temp_dir, 'api-proxy')
+    FileUtils.mkdir_p(File.join(app_dir, 'config'))
+
+    # Create database.yml with underscore naming (as Rails would)
+    database_yml = <<~YAML
+      default: &default
+        adapter: postgresql
+        encoding: unicode
+        pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+      development:
+        <<: *default
+        database: api_proxy_development
+
+      test:
+        <<: *default
+        database: api_proxy_test
+
+      production:
+        <<: *default
+        database: api_proxy_production
+        username: api_proxy
+        password: <%= ENV["API_PROXY_DATABASE_PASSWORD"] %>
+    YAML
+
+    File.write(File.join(app_dir, 'config', 'database.yml'), database_yml)
+
+    # Create cable.yml
+    cable_yml = <<~YAML
+      production:
+        adapter: redis
+        url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+        channel_prefix: api_proxy_production
+    YAML
+
+    File.write(File.join(app_dir, 'config', 'cable.yml'), cable_yml)
+
+    Dir.chdir(app_dir) do
+      # Simulate the prepare_app_vars method
+      old_dir = File.basename(Dir.getwd)
+      assert_equal 'api-proxy', old_dir
+
+      # Test the normalization
+      old_app_name_from_dir = old_dir.parameterize(separator: '_')
+      assert_equal 'api_proxy', old_app_name_from_dir
+
+      # Verify the fix would work
+      new_app_name = 'citadel'.parameterize(separator: '_')
+      assert_equal 'citadel', new_app_name
+
+      # Read the database.yml and verify it contains the underscore version
+      db_content = File.read(File.join('config', 'database.yml'))
+      assert db_content.include?('api_proxy_development')
+      assert db_content.include?('api_proxy_test')
+      assert db_content.include?('api_proxy_production')
+      assert db_content.include?('API_PROXY_DATABASE_PASSWORD')
+
+      # Read cable.yml
+      cable_content = File.read(File.join('config', 'cable.yml'))
+      assert cable_content.include?('api_proxy_production')
+    end
+  end
+
+  test "handles normal app names without hyphens" do
+    app_dir = File.join(@temp_dir, 'myapp')
+    FileUtils.mkdir_p(File.join(app_dir, 'config'))
+
+    database_yml = <<~YAML
+      development:
+        database: myapp_development
+    YAML
+
+    File.write(File.join(app_dir, 'config', 'database.yml'), database_yml)
+
+    Dir.chdir(app_dir) do
+      old_dir = File.basename(Dir.getwd)
+      assert_equal 'myapp', old_dir
+
+      old_app_name_from_dir = old_dir.parameterize(separator: '_')
+      assert_equal 'myapp', old_app_name_from_dir
+
+      # In this case, old_app_name and old_app_name_from_dir should be the same
+      # So the conditional replacements won't run
+    end
+  end
+
+  test "handles complex app names with multiple hyphens" do
+    app_dir = File.join(@temp_dir, 'my-awesome-api-proxy')
+    FileUtils.mkdir_p(File.join(app_dir, 'config'))
+
+    database_yml = <<~YAML
+      development:
+        database: my_awesome_api_proxy_development
+    YAML
+
+    File.write(File.join(app_dir, 'config', 'database.yml'), database_yml)
+
+    Dir.chdir(app_dir) do
+      old_dir = File.basename(Dir.getwd)
+      assert_equal 'my-awesome-api-proxy', old_dir
+
+      old_app_name_from_dir = old_dir.parameterize(separator: '_')
+      assert_equal 'my_awesome_api_proxy', old_app_name_from_dir
+
+      db_content = File.read(File.join('config', 'database.yml'))
+      assert db_content.include?('my_awesome_api_proxy_development')
+    end
+  end
+end


### PR DESCRIPTION
Hi! Thank you for the library. I've been using it with the updates included in this PR, and thought I would share them back in case they're useful for you too.

- Fix app name detection for Rails' underscore patterns (e.g., rails_8_template vs rails8_template) by reading database.yml
- Add support for Rails 8 files: Kamal deploy.yml, PWA manifest, Dockerfile, and multi-database configurations
- Add safe_replace_into_file() for optional file handling
- Update file search patterns to include .yml and .json.erb
- Handle humanized app names in layout titles
- Update README with Rails 8.0.2 and Ruby 3.4.5 compatibility

The name detection fix addresses the case where a module name like `Rails8Template` can map to either `rails8_template` or `rails_8_template`. The name in `database.yml` is more reliable.