### PR TITLE
Fix: Allow rename when target folder name matches current folder

### DIFF
--- a/lib/generators/rename/shared/common_methods.rb
+++ b/lib/generators/rename/shared/common_methods.rb
@@ -47,7 +47,7 @@ module CommonMethods
       raise Thor::Error, '[Error] Please give a name which does not match any of the reserved Rails keywords.'
     elsif Object.const_defined?(@new_module_name)
       raise Thor::Error, "[Error] Constant '#{@new_module_name}' is already in use, please choose another name."
-    elsif file_exist?(@new_path)
+    elsif file_exist?(@new_path) && @new_path != Rails.root.to_s
       raise Thor::Error, "[Error] Folder '#{@new_dir}' already in use, please choose another name."
     end
   end


### PR DESCRIPTION
Hi there! Here's another little change I made. Thought I'd share!

The generator was preventing rename operations when the new folder name matched the current folder name. This change allows the rename to proceed by checking if the new path is different from the current Rails root path before throwing an error.